### PR TITLE
improve enum handling

### DIFF
--- a/library/src/test/java/it/edwardday/serialization/preferences/DecodePrimitivesTest.kt
+++ b/library/src/test/java/it/edwardday/serialization/preferences/DecodePrimitivesTest.kt
@@ -24,6 +24,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class DecodePrimitivesTest {
@@ -62,8 +63,7 @@ class DecodePrimitivesTest {
 
     @Test
     fun getByte() {
-        sharedPreferences.edit().putInt("windowFlags", 0x5B)
-            .apply()
+        sharedPreferences.edit().putInt("windowFlags", 0x5B).apply()
 
         val actual = preferences.decode<Byte>("windowFlags")
 
@@ -95,8 +95,7 @@ class DecodePrimitivesTest {
 
     @Test
     fun getInt() {
-        sharedPreferences.edit().putInt("amount", 7654321)
-            .apply()
+        sharedPreferences.edit().putInt("amount", 7654321).apply()
 
         val actual = preferences.decode<Int>("amount")
 
@@ -112,8 +111,7 @@ class DecodePrimitivesTest {
 
     @Test
     fun getLong() {
-        sharedPreferences.edit()
-            .putLong("count", 10987654321).apply()
+        sharedPreferences.edit().putLong("count", 10987654321).apply()
 
         val actual = preferences.decode<Long>("count")
 
@@ -129,8 +127,7 @@ class DecodePrimitivesTest {
 
     @Test
     fun getFloat() {
-        sharedPreferences.edit().putFloat("wallet", 123.45f)
-            .apply()
+        sharedPreferences.edit().putFloat("wallet", 123.45f).apply()
 
         val actual = preferences.decode<Float>("wallet")
 
@@ -149,8 +146,7 @@ class DecodePrimitivesTest {
         preferences = Preferences(sharedPreferences) {
             doubleRepresentation = DoubleRepresentation.FLOAT
         }
-        sharedPreferences.edit().putFloat("a_value", 123.45f)
-            .apply()
+        sharedPreferences.edit().putFloat("a_value", 123.45f).apply()
 
         val actual = preferences.decode<Double>("a_value")
 
@@ -175,8 +171,7 @@ class DecodePrimitivesTest {
         preferences = Preferences(sharedPreferences) {
             doubleRepresentation = DoubleRepresentation.STRING
         }
-        sharedPreferences.edit()
-            .putString("a_value", "123.45").apply()
+        sharedPreferences.edit().putString("a_value", "123.45").apply()
 
         val actual = preferences.decode<Double>("a_value")
 
@@ -192,8 +187,7 @@ class DecodePrimitivesTest {
 
     @Test
     fun getChar() {
-        sharedPreferences.edit().putString("letter", "$")
-            .apply()
+        sharedPreferences.edit().putString("letter", "$").apply()
 
         val actual = preferences.decode<Char>("letter")
 
@@ -209,8 +203,7 @@ class DecodePrimitivesTest {
 
     @Test
     fun getString() {
-        sharedPreferences.edit()
-            .putString("theText", "loading a string").apply()
+        sharedPreferences.edit().putString("theText", "loading a string").apply()
 
         val actual = preferences.decode<String>("theText")
 
@@ -221,6 +214,33 @@ class DecodePrimitivesTest {
     fun failOnNotStoredString() {
         assertFailsWith<SerializationException> {
             preferences.decode<String>("theText")
+        }
+    }
+
+    @Test
+    fun decodeEnumMonday() {
+        sharedPreferences.edit().putString("enum", "MONDAY").apply()
+
+        val actual = preferences.decode<Weekday>("enum")
+
+        assertSame(Weekday.MONDAY, actual)
+    }
+
+    @Test
+    fun decodeEnumSunday() {
+        sharedPreferences.edit().putString("enum", "SUNDAY").apply()
+
+        val actual = preferences.decode<Weekday>("enum")
+
+        assertSame(Weekday.SUNDAY, actual)
+    }
+
+    @Test
+    fun decodeEnumNonExistent() {
+        sharedPreferences.edit().putString("enum", "NODAY").apply()
+
+        assertFailsWith<SerializationException> {
+            preferences.decode<Weekday>("enum")
         }
     }
 }

--- a/library/src/test/java/it/edwardday/serialization/preferences/EncodePrimitivesTest.kt
+++ b/library/src/test/java/it/edwardday/serialization/preferences/EncodePrimitivesTest.kt
@@ -46,8 +46,7 @@ class EncodePrimitivesTest {
     fun putBooleanNullable() {
         preferences.encode<Boolean?>("useFancyFeature", null)
 
-        val actual = sharedPreferences.contains("useFancyFeature")
-        assertFalse(actual)
+        assertTrue(sharedPreferences.all.isEmpty())
     }
 
     @Test
@@ -70,8 +69,7 @@ class EncodePrimitivesTest {
     fun putByteNullable() {
         preferences.encode<Byte?>("windowFlags", null)
 
-        val actual = sharedPreferences.contains("windowFlags")
-        assertFalse(actual)
+        assertTrue(sharedPreferences.all.isEmpty())
     }
 
     @Test
@@ -86,8 +84,7 @@ class EncodePrimitivesTest {
     fun putShortNullable() {
         preferences.encode<Short?>("age", null)
 
-        val actual = sharedPreferences.contains("age")
-        assertFalse(actual)
+        assertTrue(sharedPreferences.all.isEmpty())
     }
 
     @Test
@@ -102,8 +99,7 @@ class EncodePrimitivesTest {
     fun putIntNullable() {
         preferences.encode<Int?>("amount", null)
 
-        val actual = sharedPreferences.contains("amount")
-        assertFalse(actual)
+        assertTrue(sharedPreferences.all.isEmpty())
     }
 
     @Test
@@ -118,8 +114,7 @@ class EncodePrimitivesTest {
     fun putLongNullable() {
         preferences.encode<Long?>("count", null)
 
-        val actual = sharedPreferences.contains("count")
-        assertFalse(actual)
+        assertTrue(sharedPreferences.all.isEmpty())
     }
 
     @Test
@@ -134,8 +129,7 @@ class EncodePrimitivesTest {
     fun putFloatNullable() {
         preferences.encode<Float?>("wallet", null)
 
-        val actual = sharedPreferences.contains("wallet")
-        assertFalse(actual)
+        assertTrue(sharedPreferences.all.isEmpty())
     }
 
     @Test
@@ -145,9 +139,7 @@ class EncodePrimitivesTest {
         }
         preferences.encode("a_value", 123.45)
 
-        val actual =
-            sharedPreferences.getFloat("a_value", 0f)
-                .toDouble()
+        val actual = sharedPreferences.getFloat("a_value", 0f).toDouble()
         assertTrue(actual > 123.449)
         assertTrue(actual < 123.451)
     }
@@ -159,9 +151,7 @@ class EncodePrimitivesTest {
         }
         preferences.encode("a_value", 123.45)
 
-        val actual = Double.fromBits(
-            sharedPreferences.getLong("a_value", 0)
-        )
+        val actual = Double.fromBits(sharedPreferences.getLong("a_value", 0))
         assertEquals(123.45, actual)
     }
 
@@ -189,16 +179,14 @@ class EncodePrimitivesTest {
     fun putCharNullable() {
         preferences.encode<Char?>("letter", null)
 
-        val actual = sharedPreferences.contains("letter")
-        assertFalse(actual)
+        assertTrue(sharedPreferences.all.isEmpty())
     }
 
     @Test
     fun putString() {
         preferences.encode("theText", "a common text to save")
 
-        val actual =
-            sharedPreferences.getString("theText", null)
+        val actual = sharedPreferences.getString("theText", null)
         assertEquals("a common text to save", actual)
     }
 
@@ -206,7 +194,20 @@ class EncodePrimitivesTest {
     fun putStringNullable() {
         preferences.encode<String?>("theText", null)
 
-        val actual = sharedPreferences.contains("theText")
-        assertFalse(actual)
+        assertTrue(sharedPreferences.all.isEmpty())
+    }
+
+    @Test
+    fun putEnum() {
+        preferences.encode("enum", Weekday.WEDNESDAY)
+
+        assertEquals("WEDNESDAY", sharedPreferences.getString("enum", null))
+    }
+
+    @Test
+    fun putEnumNullable() {
+        preferences.encode<Weekday?>("enum", null)
+
+        assertTrue(sharedPreferences.all.isEmpty())
     }
 }

--- a/library/src/test/java/it/edwardday/serialization/preferences/EncodingTest.kt
+++ b/library/src/test/java/it/edwardday/serialization/preferences/EncodingTest.kt
@@ -389,4 +389,13 @@ class EncodingTest {
 
         assertEquals(data, actual)
     }
+
+    @Test
+    fun testListOfEnums() {
+        val data = listOf(Weekday.TUESDAY, Weekday.SATURDAY, Weekday.THURSDAY, Weekday.FRIDAY)
+        preferences.encode("enums", data)
+        val actual = preferences.decode<List<Weekday>>("enums")
+
+        assertEquals(data, actual)
+    }
 }

--- a/library/src/test/java/it/edwardday/serialization/preferences/Models.kt
+++ b/library/src/test/java/it/edwardday/serialization/preferences/Models.kt
@@ -79,3 +79,13 @@ val interfaceModule = SerializersModule {
         subclass(InterfaceClassTwo::class)
     }
 }
+
+enum class Weekday {
+    MONDAY,
+    TUESDAY,
+    WEDNESDAY,
+    THURSDAY,
+    FRIDAY,
+    SATURDAY,
+    SUNDAY
+}


### PR DESCRIPTION
- Int is not supported as enum backing field anymore
- throw proper SerializationException when decoding unknown enum value

Signed-off-by: EdwarDDay <4127904+EdwarDDay@users.noreply.github.com>